### PR TITLE
3.10 logging error

### DIFF
--- a/iblrig_custom_tasks/_sp_passiveVideo/task.py
+++ b/iblrig_custom_tasks/_sp_passiveVideo/task.py
@@ -151,7 +151,8 @@ class Session(BpodMixin):
         self.paths.STATS_FILE_PATH = self.paths.DATA_FILE_PATH.with_name('_sp_videoData.stats.pqt')
         self.video = None
         self.trial_num = -1
-        self._log_level = logging.getLevelNamesMapping()[kwargs.get('log_level', 'INFO')]
+        # For py3.11 use logging.getLevelNamesMapping instead
+        self._log_level = logging.getLevelName(kwargs.get('log_level', 'INFO'))
         columns = ['intervals_0', 'intervals_1']
         self.data = pd.DataFrame(pd.NA, index=range(self.task_params.NREPEATS), columns=columns)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "project_extraction"
-version         = "0.5.0post0"
+version         = "0.5.1"
 description     = "Custom extractors for satellite tasks"
 dynamic         = [ "readme" ]
 keywords        = [ "IBL", "neuro-science" ]


### PR DESCRIPTION
`logging.getLevelNamesMapping` only exists in py 3.11 - switched to using `logging.getLevelName` instead.